### PR TITLE
Previously, the spec for block level tokens was causing confusion and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,30 +17,29 @@ You should have received a copy of the GNU General Public License
 along with Rx.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-# Rx Specification
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Overview](#overview)
-- [Usage](#usage)
-  * [Inline Elements](#inline-elements)
-  * [Inline Examples](#inline-examples)
-    + [Matching Literals](#matching-literals)
-    + [Matching Mandatory tokens](#matching-mandatory-tokens)
-    + [Matching Optional Tokens](#matching-optional-tokens)
-    + [Matching Links](#matching-links)
-  * [Block Elements](#block-elements)
-  * [Block Examples](#block-examples)
-    + [Matching Mandatory Block Level tokens](#matching-mandatory-block-level-tokens)
-    + [Matching Optional Block Level tokens](#matching-optional-block-level-tokens)
-    + [Combining Block Level and Inline tokens](#combining-block-level-and-inline-tokens)
-    + [Matching Repeatable tokens](#matching-repeatable-tokens)
-  * [Special Cases](#special-cases)
-    + [Inline vs Block Level tokens](#inline-vs-block-level-tokens)
-    + [Fenced Code Blocks](#fenced-code-blocks)
-    + [HTML Comments](#html-comments)
-  * [Special Case Examples](#special-case-examples)
-    + [Matching inline tokens as the first element of a block element](#matching-inline-tokens-as-the-first-element-of-a-block-element)
-    + [Matching Block Level Tokens for Fenced Code blocks](#matching-block-level-tokens-for-fenced-code-blocks)
-    + [Matching Block Elements with HTML comments.](#matching-block-elements-with-html-comments)
+
+  - [Overview](#overview)
+  - [Usage](#usage)
+    - [Inline Elements](#inline-elements)
+    - [Inline Examples](#inline-examples)
+      - [Matching Literals](#matching-literals)
+      - [Matching Mandatory tokens](#matching-mandatory-tokens)
+      - [Matching Optional Tokens](#matching-optional-tokens)
+      - [Matching Links](#matching-links)
+    - [Block Elements](#block-elements)
+    - [Block Examples](#block-examples)
+      - [Matching Mandatory Block Elements](#matching-mandatory-block-elements)
+      - [Matching Optional Block Elements](#matching-optional-block-elements)
+      - [Combining Block Level and Inline Tokens](#combining-block-level-and-inline-tokens)
+      - [Matching Repeatable Tokens](#matching-repeatable-tokens)
+    - [Special Cases](#special-cases)
+      - [Matching Block Level Tokens for Fenced Code Blocks](#matching-block-level-tokens-for-fenced-code-blocks)
+- [License](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Overview
 
@@ -61,513 +60,416 @@ with.
 
 ## Usage
 
-*
-    ### Inline Elements
+### Inline Elements
 
-    Inline elements consist of
-    * Plain, textual content such as that within paragraphs and headings
-    * Inline code blocks
-    * Emphasis and Strong Emphasis
-    * Links
-    * Images
-    * Inline HTML
+Inline elements consist of
+* Plain, textual content such as that within paragraphs and headings
+* Inline code blocks
+* Emphasis and Strong Emphasis
+* Links
+* Images
+* Inline HTML
 
-    Rx tokens that appear in the context of inline elements represent prompts for
-    arbitrary textual content to appear according to token type.
+Rx tokens that appear in the context of inline elements represent prompts for
+arbitrary textual content to appear according to token type.
 
-    * **Literal**
-        Any textual content that is not an Rx token or a syntactic element of
-        Markdown must be matched with an identical section of text.
+* **Literal**
+    Any textual content that is not an Rx token or a syntactic element of
+    Markdown must be matched with an identical section of text.
 
-    * `-!!-`
-        **Mandatory**
+* `-!!-`
+    **Mandatory**
 
-        Some content must be inserted here. Each mandatory token must match with at
-        least one non-whitespace characters, so adjacent mandatory tokens must be
-        matched with content whose length is greater than or equal to the number of
-        tokens.
+    Some content must be inserted here. Each mandatory token must match with at
+    least one non-whitespace characters, so adjacent mandatory tokens must be
+    matched with content whose length is greater than or equal to the number of
+    tokens.
 
-    * `-??-`
-        **Optional**
+* `-??-`
+    **Optional**
 
-        Some content may be inserted here, but is not necessary for the document to
-        be considered valid.
+    Some content may be inserted here, but is not necessary for the document to
+    be considered valid.
 
-    * `-""-`
-        **Repeatable**
+* `-""-`
+    **Repeatable**
 
-        Has no signifigance in this context. Is not considered a valid usage of this
-        token.
+    Has no signifigance in this context. Is not considered a valid usage of this
+    token.
 
-    ### Inline Examples
+### Inline Examples
 
-    #### Matching Literals
+#### Matching Literals
 
-    ##### Rx
+##### Rx
 
-    ``` markdown
-    # A Heading
+```markdown
+# A Heading
 
-    Some content.
-    ```
+Some content.
+```
 
-    ##### Matches
+##### Matches
 
-    ``` markdown
-    # A Heading
+```markdown
+# A Heading
 
-    Some content.
-    ```
+Some content.
+```
 
-    ##### Rejects
+##### Rejects
 
-    ``` markdown
-    Literally anything else.
-    ```
+```markdown
+Literally anything else.
+```
 
-    #### Matching Mandatory tokens
+#### Matching Mandatory tokens
 
-    ##### Rx
+##### Rx
 
-    ``` markdown
-    # We're off to see -!!-
+```markdown
+# We're off to see -!!-
 
-    The -!!- of -!!-.
-    ```
+The -!!- of -!!-.
+```
 
-    ##### Matches
+##### Matches
 
-    ``` markdown
-    # We're off to see the wizard
+```markdown
+# We're off to see the wizard
 
-    The wonderful wizard of Oz.
-    ```
+The wonderful wizard of Oz.
+```
 
-    ``` markdown
-    # We're off to see the veterinarian
+```markdown
+# We're off to see the veterinarian
 
-    The priciest doctor of dogs.
-    ```
+The priciest doctor of dogs.
+```
 
-    ``` markdown
-    # We're off to see the optometrist
+```markdown
+# We're off to see the optometrist
 
-    The optometrist will tell us if we are in need of glasses.
-    ```
+The optometrist will tell us if we are in need of glasses.
+```
 
-    ##### Rejects
+##### Rejects
 
-    ``` markdown
-    # We're off to see
+```markdown
+# We're off to see
 
-    The dentist because our teeth are full of cavities.
-    ```
+The dentist because our teeth are full of cavities.
+```
 
-    > In this case, the Mandatory token in the heading has not been satisfied.
+> In this case, the Mandatory token in the heading has not been satisfied.
 
-    #### Matching Optional Tokens
+#### Matching Optional Tokens
 
-    ##### Rx
+##### Rx
 
-    ``` markdown
-    Seeking a -??-qualified applicant for our remote -??- offices.
-    ```
+```markdown
+Seeking a -??-qualified applicant for our remote -??- offices.
+```
 
-    ##### Matches
+##### Matches
 
-    ``` markdown
-    Seeking a woefully unqualified applicant for our remote customer support offices.
-    ```
+```markdown
+Seeking a woefully unqualified applicant for our remote customer support offices.
+```
 
-    ``` markdown
-    Seeking a qualified applicant for our remote offices.
-    ```
+```markdown
+Seeking a qualified applicant for our remote offices.
+```
 
-    ##### Rejects
+##### Rejects
 
-    ``` markdown
-    Seeking a marginally qualified applicant for our remote call center.
-    ```
-    > An inline Optional token cannot by itself cause a mismatch since it can match
-    > any textual content or nothing. In this case the mismatch is triggered by the
-    > Literal content `offices` being omitted.
+```markdown
+Seeking a marginally qualified applicant for our remote call center.
+```
+> An inline Optional token cannot by itself cause a mismatch since it can match
+> any textual content or nothing. In this case the mismatch is triggered by the
+> Literal content `offices` being omitted.
 
-    #### Matching Links
+#### Matching Links
 
-    ##### Rx
+##### Rx
 
-    ``` markdown
-    Please [visit](https:://-!!-.polysync.io) us on the web!
-    ```
+```markdown
+Please [visit](https:://-!!-.polysync.io) us on the web!
+```
 
-    ##### Matches
+##### Matches
 
-    ``` markdown
-    Please [visit](https:://www.polysync.io) us on the web!
-    ```
+```markdown
+Please [visit](https:://www.polysync.io) us on the web!
+```
 
-    ``` markdown
-    Please [visit](https:://www.rx.polysync.io) us on the web!
-    ```
+```markdown
+Please [visit](https:://www.rx.polysync.io) us on the web!
+```
 
-    ##### Rejects
+##### Rejects
 
-    ``` markdown
-    Please [visit](https:://.polysync.io) us on the web!
-    ```
+```markdown
+Please [visit](https:://.polysync.io) us on the web!
+```
 
-    > Rejected because there was no prefix specified in the uri.
+> Rejected because there was no prefix specified in the uri.
 
-    ``` markdown
-    Please [visit](http:://scam.polysync.io) us on the web!
-    ```
+```markdown
+Please [visit](http:://scam.polysync.io) us on the web!
+```
 
-    > Rejected because the `s` was omitted from the protocol portion of the uri.
+> Rejected because the `s` was omitted from the protocol portion of the uri.
 
 
-*
-    ### Block Elements
+### Block Elements
 
-    Block elements contain inline elements and in some cases other block elements.
-    They consist of
-    * List Items
-    * Block Quotes
-    * Paragraphs
-    * Headings
-    * Code Blocks
-    * HTML Blocks
+Block elements contain inline elements and in some cases other block elements.
+They consist of
+* List Items
+* Block Quotes
+* Paragraphs
+* Headings
+* Code Blocks
+* HTML Blocks
 
-    If the first textual content of a block element begins with an Rx token, then
-    that token is considered a 'Block Level Token' and its meaning applies to the
-    entire scope of that block.
+If the first line of the block element is an Rx token by itself, then
+that token is considered a 'Block Level Token' and its meaning applies to the
+entire scope of that block.
 
-    * **Literal**
-        Strictly speaking, block elements do not directly contain Literals since all
-        textual content is conceptualized as being within inline elements. That
-        being said, the Literal content appearing within block elements must be
-        matched identically just like in the rule for inline Literal elements, but
-        the requirement of its presence or absence can be specified the presence of
-        the following Block Level Tokens.
+* **Literal**
+    Strictly speaking, block elements do not directly contain Literals since all
+    textual content is conceptualized as being within inline elements. That
+    being said, the Literal content appearing within block elements must be
+    matched identically just like in the rule for inline Literal elements, but
+    the requirement of its presence or absence can be specified the presence of
+    the following Block Level Tokens.
 
-    * `-!!-`
-        **Mandatory**
+* `-!!-`
+    **Mandatory**
 
-        - Element contains additional inline content or block elements.
-            A block element of the same type **must** appear in this position in the
-            matching document. In order to be considered a match, all inline and and
-            block elements contained within the scope of this element must also be
-            matched according to their relevant matching rules.
-        - Element does not contain any additional content.
-            A block element of the same type **must** appear in this position in the
-            document however, the matching element may contain any arbitrary inline
-            and/or block elements.
+    - Element contains additional inline content or block elements on subsequent lines.
+        A block element of the same type **must** appear in this position in the
+        matching document. In order to be considered a match, all inline and and
+        block elements contained within the scope of this element must also be
+        matched according to their relevant matching rules.
+    - Element does not contain any additional content.
+        A block element of the same type **must** appear in this position in the
+        document however, the matching element may contain any arbitrary inline
+        and/or block elements.
 
-    * `-??-`
-        **Optional**
+* `-??-`
+    **Optional**
 
-        - Element contains additional inline content or block elements.
-            A block element of the same type **may** appear in this position in the
-            matching document but is not necessary. If an element does appear, in
-            order to be considerer a match, all inline and and block elements
-            contained within the scope of this element must also be matched
-            according to their relevant matching rules.
-        - Element does not contain any additional content.
-            A block element of the same type **may** appear in this position in the
-            document, but is not necessary. If an element does appear, it may
-            contain any arbitrary inline and/or block elements and still be
-            considered a match.
+    - Element contains additional inline content or block elements on subsequent lines.
+        A block element of the same type **may** appear in this position in the
+        matching document but is not necessary. If an element does appear, in
+        order to be considerer a match, all inline and and block elements
+        contained within the scope of this element must also be matched
+        according to their relevant matching rules.
+    - Element does not contain any additional content.
+        A block element of the same type **may** appear in this position in the
+        document, but is not necessary. If an element does appear, it may
+        contain any arbitrary inline and/or block elements and still be
+        considered a match.
 
-    * `-""-`
-        **Repeatable**
+* `-""-`
+    **Repeatable**
 
-        This token must appear in a block element that does not contain any other
-        block or inline elements and whose type matches the previous
-        block element in the document. It matches any number of block elements that
-        match the previous block element.
+    This token must appear in a block element that does not contain any other
+    block or inline elements and whose type matches the previous
+    block element at the same level in the document. It matches any number of block elements that
+    match the previous block element.
 
-    ### Block Examples
+### Block Examples
 
-    #### Matching Mandatory Block Level tokens
+#### Matching Mandatory Block Elements
 
-    ##### Rx
+##### Rx
 
-    ``` markdown
-    # -!!- The wonderful thing about tiggers
+```markdown
+# -!!-
+# The wonderful thing about tiggers
 
-    -!!- Is tiggers are wonderful things!
-    ```
+-!!-
+Is tiggers are wonderful things!
+```
 
-    ##### Matches
+which in this case is equivalent to
 
-    ``` markdown
-    # The wonderful thing about tiggers
+```markdown
+# The wonderful thing about tiggers
 
-    Is tiggers are wonderful things!
-    ```
+Is tiggers are wonderful things!
+```
 
-    ##### Rejects
+##### Matches
 
-    ``` markdown
-    The wonderful thing about tiggers
+```markdown
+# The wonderful thing about tiggers
 
-    Is tiggers are wonderful things!
-    ```
-    > Rejected because although the text of the first block matches, it is not
-    > part of the same type of block element.
+Is tiggers are wonderful things!
+```
 
-    ``` markdown
-    # The wonderful thing about tiggers
+##### Rejects
 
-    Is tiggers are wonderful things!
+```markdown
+The wonderful thing about tiggers
 
-    Their tops are made out of rubber
+Is tiggers are wonderful things!
+```
+> Rejected because although the text of the first block matches, it is not
+> part of the same type of block element.
 
-    Their bottoms are made out of springs!
-    ```
-    > Rejected because of superflous paragraphs included at the end.
+```markdown
+# The wonderful thing about tiggers
 
-    #### Matching Optional Block Level tokens
+Is tiggers are wonderful things!
 
-    ##### Rx
+Their tops are made out of rubber
 
-    ``` markdown
-    Four score and seven years ago our fathers brought forth on this continent a new
-     nation, conceived in Liberty, and dedicated to the proposition that all men are
-     created equal.
+Their bottoms are made out of springs!
+```
+> Rejected because of superflous paragraphs included at the end.
 
-    -??- Now we are engaged in a great civil war, testing whether that nation or any
-    nation so conceived and so dedicated, can long endure....
+#### Matching Optional Block Elements
 
-    -??- But, in a larger sense, we can not dedicate—we can not consecrate—we can
-    not hallow—this ground....
+##### Rx
 
-    -??- TLDR; -!!-
-    ```
+```markdown
+Four score and seven years ago our fathers brought forth on this continent a new
+ nation, conceived in Liberty, and dedicated to the proposition that all men are
+ created equal.
 
-    ##### Matches
+-??-
+Now we are engaged in a great civil war, testing whether that nation or any
+nation so conceived and so dedicated, can long endure....
 
-    ``` markdown
-    Four score and seven years ago our fathers brought forth on this continent a new
-     nation, conceived in Liberty, and dedicated to the proposition that all men are
-     created equal.
+-??-
+But, in a larger sense, we can not dedicate—we can not consecrate—we can
+not hallow—this ground....
 
-    Now we are engaged in a great civil war, testing whether that nation or any
-    nation so conceived and so dedicated, can long endure....
+> -??-
+> TLDR; -!!-
+```
 
-    But, in a larger sense, we can not dedicate—we can not consecrate—we can
-    not hallow—this ground....
-    ```
+##### Matches
 
-    ``` markdown
-    Four score and seven years ago our fathers brought forth on this continent a new
-     nation, conceived in Liberty, and dedicated to the proposition that all men are
-     created equal.
+```markdown
+Four score and seven years ago our fathers brought forth on this continent a new
+ nation, conceived in Liberty, and dedicated to the proposition that all men are
+ created equal.
 
-    TLDR; We must finish what we have started my dudes.
-    ```
+Now we are engaged in a great civil war, testing whether that nation or any
+nation so conceived and so dedicated, can long endure....
 
-    ##### Rejects
+But, in a larger sense, we can not dedicate—we can not consecrate—we can
+not hallow—this ground....
+```
 
-    ``` markdown
-    Four score and seven years ago our fathers brought forth on this continent a new
-     nation, conceived in Liberty, and dedicated to the proposition that all men are
-     created equal.
+```markdown
+Four score and seven years ago our fathers brought forth on this continent a new
+ nation, conceived in Liberty, and dedicated to the proposition that all men are
+ created equal.
 
-    TLDR;
-    ```
-    > Optional Block Level Tokens can only cause a mismatch if they are present, but
-    > contain some other inline or block elements that exhibit a mismatch. In this
-    > case, the Mandatory inline token was not satisfied.
+> TLDR; We must finish what we have started my dudes.
+```
 
-    #### Combining Block Level and Inline tokens
+#### Combining Block Level and Inline Tokens
 
-    ##### Rx
+##### Rx
 
-    ``` markdown
-    A literal intro paragraph.
+```markdown
+A literal intro paragraph.
 
-    -!!- A mandatory paragraph about -!!-.
+-!!-
+A mandatory paragraph about -!!-.
 
-    -""-
+-""-
 
-    -??- An optional closing paragraph that must say this if present.
-    ```
+-??-
+An optional closing paragraph that must say this if present.
+```
 
-    ##### Matches
+##### Matches
 
-    ``` markdown
-    A literal mandatory intro paragraph.
+```markdown
+A literal mandatory intro paragraph.
 
-    A mandatory paragraph about turnips.
+A mandatory paragraph about turnips.
 
-    A mandatory paragraph about bacon.
+A mandatory paragraph about bacon.
 
-    An optional closing paragraph that must say this if present.
-    ```
+An optional closing paragraph that must say this if present.
+```
 
-    ``` markdown
-    A literal intro paragraph.
+```markdown
+A literal intro paragraph.
 
-    A mandatory paragraph about superheroes.
-    ```
+A mandatory paragraph about superheroes.
+```
 
-    ##### Rejects
+##### Rejects
 
-    ``` markdown
-    A literal intro paragraph.
-    ```
+```markdown
+A literal intro paragraph.
+```
 
-    ``` markdown
-    A verbatim intro paragraph.
+```markdown
+A verbatim intro paragraph.
 
-    An optional closing paragraph that must say this if present.
-    ```
+An optional closing paragraph that must say this if present.
+```
 
-    #### Matching Repeatable tokens
+#### Matching Repeatable Tokens
 
-    ##### Rx
+##### Rx
 
-    ``` markdown
-    * First Item
-    * -""-
-    * Last Item
-    ```
+```markdown
+* First Item
+* -""-
+* Last Item
+```
 
-    ##### Matches
+##### Matches
 
-    ``` markdown
-    * First Item
-    * Second Item
-    * Third Item
-    * Last Item
-    ```
+```markdown
+* First Item
+* Second Item
+* Third Item
+* Last Item
+```
 
-    ``` markdown
-    * First Item
-    * Last Item
-    ```
+```markdown
+* First Item
+* Last Item
+```
 
-*
-    ### Special Cases
+### Special Cases
 
-    #### Inline vs Block Level tokens
+#### Matching Block Level Tokens for Fenced Code Blocks
 
-    In order to specify a prompt for some inline content at the
-    beginning of a paragraph, in order for the token to not be interpreted as a
-    block element token, a block element token must precede it.
+To specify a block level token for a fenced code block, place it at the beginning of the info string.
 
-    #### Fenced Code Blocks
+##### Rx
 
-    Due to the special formatting of Fenced Code Blocks, their block element tokens
-    must be placed at the end of their info strings.
+```markdown
+~~~-!!-rust
+-!!-
+~~~
+```
 
-    #### HTML Comments
+##### Accepts
 
-    HTML comments that appear as the last inline content in a block element will be
-    ignored with respect to matching rules.
-
-    ### Special Case Examples
-
-    #### Matching inline tokens as the first element of a block element
-
-    ##### Rx
-
-    ``` markdown
-    -!!- is my favorite color.
-    ```
-    > **Wrong**. The token is interpreted as a block element token.
-
-    ##### Matches
-
-    ``` markdown
-     is my favorite color.
-    ```
-
-    ##### Rejects
-
-    ``` markdown
-    Red is my favorite color.
-    ```
-
-    ##### Rx
-
-    ``` markdown
-    -!!--!!- is my favorite color.
-    ```
-    > **Correct**. The first token is interpreted as a block element token, while the second
-    > is interpreted as a prompt for content.
-
-    ##### Matches
-
-    ``` markdown
-    Red is my favorite color.
-    ```
-
-    ##### Rejects
-
-    ``` markdown
-    is my favorite color.
-    ```
-
-    #### Matching Block Level Tokens for Fenced Code blocks
-
-    ##### Rx
-
-    ``` markdown
-    ~~~ -!!- rust
-    -!!-
-    ~~~
-    ```
-    > **Wrong**. The language info for the code block will not be interpreted
-    > correctly.
-
-    ##### Rx
-
-    ``` markdown
-    ~~~ rust -!!-
-    -!!-
-    ~~~
-    ```
-    > **Correct**. Indicates a mandatory code block with rust syntax.
-
-    ##### Accepts
-
-    ``` markdown
-    ~~~ rust
-    struct Foo {
-        bar: u32,
-        baz: u32
-    };
-    ~~~
-    ```
-
-    #### Matching Block Elements with HTML comments.
-
-    ##### Rx
-
-    ``` markdown
-    # The Fresh -!!- of -!!- <!--Your title and locale-->
-
-    Now this is a story all about how -!!- <!--Tell what happened to your life-->
-    ```
-
-    ##### Matches
-
-    ``` markdown
-    # The Fresh Prince of Bel-Air
-
-    Now this is a story all about how my life got flipped-turned upside down
-    ```
-
-    ##### Rejects
-
-    ``` markdown
-    # The Fresh Prince of Bel-Air <!--Your title and locale-->
-
-    Now this is a story all about how my life got flipped-turned upside down <!--Tell what happened to your life-->
-    ```
-    > Rejected because the comment in the Rx file is ignored, so the comment in the
-    > document will be treated as superfluous content.
+```markdown
+~~~rust
+struct Foo {
+    bar: u32,
+    baz: u32
+};
+~~~
+```
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with Rx.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
+# Rx Specification
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 


### PR DESCRIPTION
… implementation problems. This commit updates the spec to require specifying block level tokens on their own line. It also removes the special handling of comment blocks. The functionality to provide useful content prompts will likely be implemented in the future in the form of WIP annotations.